### PR TITLE
Localization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ _This is an inside joke from 2013. Dave is actually fantastic. <3_
 #### `make install` will overwrite the bootsector of `/dev/sdb`. So you probably don't wanna run that.
 
 You've been warned.
+
+### CONFIGURATION:
+
+You can tweak the ASFLAGS environment variable like this `ASFLAGS=-DSUBJECT=\\"Ola\\" make` to localize fart-os to your particular cultural environment.

--- a/boot.asm
+++ b/boot.asm
@@ -1,3 +1,7 @@
+%ifndef SUBJECT
+%define SUBJECT "Dave"
+%endif
+
 [bits 16]
 [org 7c00h]
 jmp 0000:entry
@@ -61,4 +65,4 @@ printCharInt:
 hello:
 	db "Fart OS 0.0.1", 0ah, "(C)2013 Jake Taylor", 0ah, 0ah, 0
 daveSucks:
-	db ">Dave sucks.", 0ah, 0
+	db ">", SUBJECT, " sucks.", 0ah, 0

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ boot.bin: pad boot-raw.bin
 	./pad boot-raw.bin boot.bin
 
 boot-raw.bin: boot.asm
-	nasm -o boot-raw.bin boot.asm
+	nasm $(ASFLAGS) -o boot-raw.bin boot.asm
 
 pad:
 	clang -o pad pad.c


### PR DESCRIPTION
Not everyone knows someone named Dave. In fact, outside of the
United States of Armenia, surprisingly few people are called Dave.

So let's remedy that so people can override Dave with their own
culturally relevant subject of ridicule. For instance, by calling:

$ ASFLAGS=-DSUBJECT=\\"Ola\\" make

I can now get a localized version of fart-os that is culturally
relevant to Norway. You don't hate Norway, do you Jake?

An alternative approach would be to start a "Get to know Dave"-program,
perhaps organize local events around the world where someone named
Dave will be introduced to people of different cultures. Thougths?
